### PR TITLE
fix: Incorrect Regex for doubles

### DIFF
--- a/src/main/java/seedu/address/model/recipe/Ingredient.java
+++ b/src/main/java/seedu/address/model/recipe/Ingredient.java
@@ -26,7 +26,7 @@ public class Ingredient {
     /*
      * The quantity of the ingredient must be a valid number.
      */
-    public static final String QUANTITY_VALIDATION_REGEX = "\\d";
+    public static final String QUANTITY_VALIDATION_REGEX = "[0-9]+\\.?[0-9]*|\\.[0-9]+";
 
     /**
      * The first character of the quantifier must not be a whitespace,


### PR DESCRIPTION
QUANTITY_VALIDATION_REGEX rejects Strings formatted as a decimal number (e.g. "1.5")

This is incorrect behaviour as the quantity field in Ingredient is stored as a double
and should allow for this.

Let's change the QUANTITY_VALIDATION_REGEX to allow for Strings formatted as 
decimal numbers to pass the validation. 