### PR TITLE
fix: allowed creation of Ingredient with 2 fields

### DIFF
--- a/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
@@ -208,4 +208,5 @@ public class RecipeBookParserUtil {
         if (!StringUtil.isNonZeroPositiveDouble(quantity)) {
             throw new ParseException(Ingredient.QUANTITY_CONSTRAINTS);
         }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
@@ -24,7 +24,7 @@ public class RecipeBookParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero positive integer.";
     public static final String MESSAGE_MISSING_INGREDIENT_FIELDS =
-            "Ingredient is not in the <name> <quantity> <quantifier> format.";
+            "Ingredient is not in the <name> <quantity> [<quantifier>] format.";
 
     /**
      * Parses a {@code String oneBasedIndex} into an {@code Index} and returns it. <br>

--- a/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
@@ -199,7 +199,7 @@ public class RecipeBookParserUtil {
         }
         return tagSet;
     }
-    
+
     private static void isValidIngredientInput(String name, String quantity) throws ParseException {
         if (!Ingredient.isValidIngredientName(name)) {
             throw new ParseException(Ingredient.NAME_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
@@ -73,29 +73,32 @@ public class RecipeBookParserUtil {
         String[] splitIngredient = ingredient.split(Ingredient.QUANTITY_VALIDATION_REGEX);
 
         // String split should be [ingredient, quantifier]
-        if (splitIngredient.length != 2) {
+
+        String name;
+        String quantity;
+        String quantifier;
+
+        switch (splitIngredient.length) {
+        case 1: // (name, quantity) case
+            name = splitIngredient[0].trim();
+            quantity = numberMatcher.group(0).trim();
+
+            isValidIngredientInput(name, quantity);
+
+            return new Ingredient(name, Double.parseDouble(quantity));
+
+        case 2: // (name, quantity, quantifier) case
+            name = splitIngredient[0].trim();
+            quantity = numberMatcher.group(0).trim();
+            quantifier = splitIngredient[1].trim();
+
+            isValidIngredientInput(name, quantity);
+
+            return new Ingredient(name, Double.parseDouble(quantity), quantifier);
+
+        default:
             throw new ParseException(MESSAGE_MISSING_INGREDIENT_FIELDS);
         }
-
-        String name = splitIngredient[0].trim();
-        String quantity = numberMatcher.group(0).trim();
-        String quantifier = splitIngredient[1].trim();
-
-        if (!Ingredient.isValidIngredientName(name)) {
-            throw new ParseException(Ingredient.NAME_CONSTRAINTS);
-        }
-
-        if (!StringUtil.isNonZeroPositiveDouble(quantity)) {
-            throw new ParseException(Ingredient.QUANTITY_CONSTRAINTS);
-        }
-
-        if (!Ingredient.isValidQuantifier(quantifier)) {
-            throw new ParseException(Ingredient.QUANTIFIER_CONSTRAINTS);
-        }
-
-        // ---------------------------
-
-        return new Ingredient(name, Double.parseDouble(quantity), quantifier);
     }
 
     /**
@@ -165,5 +168,15 @@ public class RecipeBookParserUtil {
             stepList.add(parseStep(step));
         }
         return stepList;
+    }
+
+    private static void isValidIngredientInput(String name, String quantity) throws ParseException {
+        if (!Ingredient.isValidIngredientName(name)) {
+            throw new ParseException(Ingredient.NAME_CONSTRAINTS);
+        }
+
+        if (!StringUtil.isNonZeroPositiveDouble(quantity)) {
+            throw new ParseException(Ingredient.QUANTITY_CONSTRAINTS);
+        }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/RecipeBookSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookSyntax.java
@@ -10,6 +10,6 @@ public class RecipeBookSyntax {
     public static final Prefix PREFIX_INGREDIENT = new Prefix("-i");
     public static final Prefix PREFIX_COMPLETION_TIME = new Prefix("-d");
     public static final Prefix PREFIX_SERVING_SIZE = new Prefix("-ss:");
-    public static final Prefix PREFIX_STEPS = new Prefix("-s");
+    public static final Prefix PREFIX_STEP = new Prefix("-s");
     public static final Prefix PREFIX_TAG = new Prefix("-t");
 }

--- a/src/main/java/seedu/address/model/recipe/Ingredient.java
+++ b/src/main/java/seedu/address/model/recipe/Ingredient.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 /**
  * Represents a Recipe's ingredient in the recipe book.
  * Guarantees: immutable; is valid as declared in {@link #isValidIngredientName(String)},
- * {@link #isValidQuantity(double)}, and {@link #isValidQuantifier(String)}.
+ * and {@link #isValidQuantity(double)}.
  */
 public class Ingredient {
 

--- a/src/main/java/seedu/address/model/recipe/Ingredient.java
+++ b/src/main/java/seedu/address/model/recipe/Ingredient.java
@@ -28,12 +28,6 @@ public class Ingredient {
      */
     public static final String QUANTITY_VALIDATION_REGEX = "[0-9]+\\.?[0-9]*|\\.[0-9]+";
 
-    /**
-     * The first character of the quantifier must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String QUANTIFIER_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
-
     public final String ingredientName;
     public final double quantity;
     public final String quantifier;
@@ -43,7 +37,7 @@ public class Ingredient {
      *
      * @param name A valid name.
      * @param quantity A valid quantity.
-     * @param quantifier A valid quantifier.
+     * @param quantifier A valid quantifier, blanks are allowed.
      */
     public Ingredient(String name, double quantity, String quantifier) {
         requireNonNull(name);
@@ -51,12 +45,18 @@ public class Ingredient {
 
         checkArgument(isValidQuantity(quantity), QUANTITY_CONSTRAINTS);
 
-        requireNonNull(quantifier);
-        checkArgument(isValidQuantifier(quantifier), QUANTIFIER_CONSTRAINTS);
+
+        if (quantifier == null) {
+            quantifier = "";
+        }
 
         this.ingredientName = name;
         this.quantity = quantity;
-        this.quantifier = quantifier;
+        this.quantifier = quantifier.trim();
+    }
+
+    public Ingredient(String name, double quantity) {
+        this(name, quantity, "");
     }
 
     public String getIngredientName() {
@@ -77,10 +77,6 @@ public class Ingredient {
 
     public static boolean isValidQuantity(double test) {
         return test > 0;
-    }
-
-    public static boolean isValidQuantifier(String test) {
-        return test.matches(QUANTIFIER_VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/newstorage/JsonAdaptedIngredient.java
+++ b/src/main/java/seedu/address/newstorage/JsonAdaptedIngredient.java
@@ -70,10 +70,6 @@ class JsonAdaptedIngredient {
             throw new IllegalValueException(Ingredient.QUANTITY_CONSTRAINTS);
         }
 
-        if (!Ingredient.isValidQuantifier(quantifier)) {
-            throw new IllegalValueException(Ingredient.QUANTIFIER_CONSTRAINTS);
-        }
-
         return new Ingredient(ingredientName, dblQuantity, quantifier);
     }
 


### PR DESCRIPTION
Discussed about the case of "egg 1" and agreed that the quantifier field
should be kept optional. This means that we also remove the valid
quantifier check.

This affects the following apart from Ingredient:
- RecipeBookParserUtil
- JsonAdaptedIngredient