### PR TITLE
test: include test for FindCommand and its parser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -23,6 +25,10 @@ public class FindCommand extends Command {
 
     public FindCommand(RecipeContainsKeywordPredicate recipePredicate) {
         this.recipePredicate = recipePredicate;
+    }
+
+    public RecipeContainsKeywordPredicate getRecipePredicate() {
+        return recipePredicate;
     }
 
     @Override
@@ -49,5 +55,10 @@ public class FindCommand extends Command {
 
         FindCommand other = (FindCommand) o;
         return recipePredicate.equals(other.recipePredicate); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getRecipePredicate());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -30,7 +32,10 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         String[] keywords = trimmedArgs.split(",");
+        List<String> trimmedKeywords = Arrays.stream(keywords)
+                .map(String::trim)
+                .collect(Collectors.toUnmodifiableList());
 
-        return new FindCommand(new RecipeContainsKeywordPredicate(Arrays.asList(keywords)));
+        return new FindCommand(new RecipeContainsKeywordPredicate(trimmedKeywords));
     }
 }

--- a/src/main/java/seedu/address/model/recipe/RecipeContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeContainsKeywordPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.recipe;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -13,6 +14,10 @@ public class RecipeContainsKeywordPredicate implements Predicate<Recipe> {
 
     public RecipeContainsKeywordPredicate(List<String> keywords) {
         this.keywords = keywords;
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
     }
 
     @Override
@@ -31,7 +36,11 @@ public class RecipeContainsKeywordPredicate implements Predicate<Recipe> {
         }
 
         RecipeContainsKeywordPredicate other = (RecipeContainsKeywordPredicate) o;
-        return this.equals(other);
+        return this.getKeywords().equals(other.getKeywords());
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.getKeywords());
+    }
 }

--- a/src/main/java/seedu/address/model/recipe/RecipeContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeContainsKeywordPredicate.java
@@ -20,15 +20,12 @@ public class RecipeContainsKeywordPredicate implements Predicate<Recipe> {
         return keywords;
     }
 
-    public List<String> getKeywords() {
-        return keywords;
-    }
-
     @Override
     public boolean test(Recipe recipe) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.recipeContainsIgnoreCase(recipe.getSearchSet().toString(), keyword));
     }
+    
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof RecipeContainsKeywordPredicate)) {

--- a/src/main/java/seedu/address/model/recipe/RecipeContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/recipe/RecipeContainsKeywordPredicate.java
@@ -25,7 +25,7 @@ public class RecipeContainsKeywordPredicate implements Predicate<Recipe> {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.recipeContainsIgnoreCase(recipe.getSearchSet().toString(), keyword));
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof RecipeContainsKeywordPredicate)) {

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -72,7 +72,7 @@ class FindCommandTest {
         List<Recipe> expectedResults = List.of(FRIED_RICE, DUCK_RICE, SUSHI, SHOYU_RAMEN);
 
         expectedModel.updateFilteredRecipeList(singlePred);
-        assertCommandSuccess(cmd, model,expectedMessage, expectedModel);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
 
         List<Recipe> modelResults = model.getFilteredRecipeList();
         assertTrue(filteredListEquality(modelResults, expectedResults));

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -1,0 +1,134 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_RECIPES_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TestUtil.filteredListEquality;
+import static seedu.address.testutil.TypicalRecipes.AGLIO_OLIO;
+import static seedu.address.testutil.TypicalRecipes.DUCK_RICE;
+import static seedu.address.testutil.TypicalRecipes.FRIED_RICE;
+import static seedu.address.testutil.TypicalRecipes.SHOYU_RAMEN;
+import static seedu.address.testutil.TypicalRecipes.SUSHI;
+import static seedu.address.testutil.TypicalRecipes.getTypicalRecipeBook;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.recipe.Recipe;
+import seedu.address.model.recipe.RecipeContainsKeywordPredicate;
+import seedu.address.testutil.TypicalRecipes;
+
+/** These tests heavily relies on {@link TypicalRecipes#getTypicalRecipeBook()} */
+class FindCommandTest {
+    private final Model model = new ModelManager(getTypicalRecipeBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(getTypicalRecipeBook(), new UserPrefs());
+
+    /** Duplicate from FindCommandParserTest */
+    @Test
+    public void execute_zeroKeywords_throwsException() {
+        RecipeContainsKeywordPredicate pred = new RecipeContainsKeywordPredicate(List.of(" "));
+        FindCommand cmd = new FindCommand(pred);
+        String expectedMessage = "String value cannot be empty";
+
+        assertThrows(IllegalArgumentException.class, () -> expectedModel.updateFilteredRecipeList(pred),
+                expectedMessage);
+    }
+
+    @Test
+    public void execute_singleKeyword_zeroResult() {
+        RecipeContainsKeywordPredicate zeroPred = new RecipeContainsKeywordPredicate(List.of("STILL MAINDENLESS?"));
+        FindCommand cmd = new FindCommand(zeroPred);
+        String expectedMessage = String.format(MESSAGE_RECIPES_LISTED_OVERVIEW, 0);
+
+        expectedModel.updateFilteredRecipeList(zeroPred);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
+        assertTrue(model.getFilteredRecipeList().isEmpty());
+    }
+
+    @Test
+    public void execute_singleKeyword_singleResult() {
+        RecipeContainsKeywordPredicate singlePred =
+                new RecipeContainsKeywordPredicate(List.of(AGLIO_OLIO.getName().fullName));
+        FindCommand cmd = new FindCommand(singlePred);
+        String expectedMessage = String.format(MESSAGE_RECIPES_LISTED_OVERVIEW, 1);
+
+        expectedModel.updateFilteredRecipeList(singlePred);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
+        assertEquals(List.of(AGLIO_OLIO), model.getFilteredRecipeList());
+    }
+
+    @Test
+    public void execute_singleKeyword_multiResult() {
+        RecipeContainsKeywordPredicate singlePred = new RecipeContainsKeywordPredicate(List.of("asian"));
+        FindCommand cmd = new FindCommand(singlePred);
+        String expectedMessage = String.format(MESSAGE_RECIPES_LISTED_OVERVIEW, 4);
+        List<Recipe> expectedResults = List.of(FRIED_RICE, DUCK_RICE, SUSHI, SHOYU_RAMEN);
+
+        expectedModel.updateFilteredRecipeList(singlePred);
+        assertCommandSuccess(cmd, model,expectedMessage, expectedModel);
+
+        List<Recipe> modelResults = model.getFilteredRecipeList();
+        assertTrue(filteredListEquality(modelResults, expectedResults));
+    }
+
+    @Test
+    public void execute_multiKeyword_singleResult() {
+        RecipeContainsKeywordPredicate multiPred =
+                new RecipeContainsKeywordPredicate(List.of(AGLIO_OLIO.getName().fullName, "MAINDENLESS??"));
+        FindCommand cmd = new FindCommand(multiPred);
+        String expectedMessage = String.format(MESSAGE_RECIPES_LISTED_OVERVIEW, 1);
+
+        expectedModel.updateFilteredRecipeList(multiPred);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
+        assertEquals(model.getFilteredRecipeList().size(), 1);
+    }
+
+    @Test
+    public void execute_multiKeyword_multiResult() {
+        RecipeContainsKeywordPredicate multiPred =
+                new RecipeContainsKeywordPredicate(List.of("asian", AGLIO_OLIO.getName().fullName, "STILL MAIDENLESS"));
+        FindCommand cmd = new FindCommand(multiPred);
+        String expectedMessage = String.format(MESSAGE_RECIPES_LISTED_OVERVIEW, 5);
+        List<Recipe> expectedResults = List.of(AGLIO_OLIO, FRIED_RICE, DUCK_RICE, SUSHI, SHOYU_RAMEN);
+
+        expectedModel.updateFilteredRecipeList(multiPred);
+        assertCommandSuccess(cmd, model, expectedMessage, expectedModel);
+        List<Recipe> modelResults = model.getFilteredRecipeList();
+        assertTrue(filteredListEquality(modelResults, expectedResults));
+    }
+
+    @Test
+    public void equals_test() {
+        RecipeContainsKeywordPredicate pred1 = new RecipeContainsKeywordPredicate(List.of("test-01"));
+        RecipeContainsKeywordPredicate pred1Copy = new RecipeContainsKeywordPredicate(pred1.getKeywords());
+        RecipeContainsKeywordPredicate pred2 = new RecipeContainsKeywordPredicate(List.of("test-02"));
+        FindCommand fc1 = new FindCommand(pred1);
+        FindCommand fc1Copy = new FindCommand(pred1Copy);
+        FindCommand fc2 = new FindCommand(pred2);
+
+        assertNotEquals(fc1, fc1.getRecipePredicate());
+        assertEquals(fc1, fc1);
+        assertEquals(fc1, fc1Copy);
+        assertNotEquals(fc1, fc2);
+    }
+
+    @Test
+    public void hashCode_test() {
+        RecipeContainsKeywordPredicate pred1 = new RecipeContainsKeywordPredicate(List.of("test-01"));
+        RecipeContainsKeywordPredicate pred1Copy = new RecipeContainsKeywordPredicate(pred1.getKeywords());
+        RecipeContainsKeywordPredicate pred2 = new RecipeContainsKeywordPredicate(List.of("test-02"));
+        FindCommand fc1 = new FindCommand(pred1);
+        FindCommand fc1Copy = new FindCommand(pred1Copy);
+        FindCommand fc2 = new FindCommand(pred2);
+
+        assertEquals(fc1.hashCode(), fc1Copy.hashCode());
+        assertNotEquals(fc1.hashCode(), fc2.hashCode());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
+++ b/src/test/java/seedu/address/logic/parser/CommandParserTestUtil.java
@@ -1,38 +1,38 @@
-// package seedu.address.logic.parser;
-//
-// import static org.junit.jupiter.api.Assertions.assertEquals;
-//
-// import seedu.address.logic.commands.Command;
-// import seedu.address.logic.parser.exceptions.ParseException;
-//
-// /**
-//  * Contains helper methods for testing command parsers.
-//  */
-// public class CommandParserTestUtil {
-//
-//     /**
-//      * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
-//      * equals to {@code expectedCommand}.
-//      */
-//     public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
-//         try {
-//             Command command = parser.parse(userInput);
-//             assertEquals(expectedCommand, command);
-//         } catch (ParseException pe) {
-//             throw new IllegalArgumentException("Invalid userInput.", pe);
-//         }
-//     }
-//
-//     /**
-//      * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
-//      * equals to {@code expectedMessage}.
-//      */
-//     public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
-//         try {
-//             parser.parse(userInput);
-//             throw new AssertionError("The expected ParseException was not thrown.");
-//         } catch (ParseException pe) {
-//             assertEquals(expectedMessage, pe.getMessage());
-//         }
-//     }
-// }
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Contains helper methods for testing command parsers.
+ */
+public class CommandParserTestUtil {
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} is successful and the command created
+     * equals to {@code expectedCommand}.
+     */
+    public static void assertParseSuccess(Parser parser, String userInput, Command expectedCommand) {
+        try {
+            Command command = parser.parse(userInput);
+            assertEquals(expectedCommand, command);
+        } catch (ParseException pe) {
+            throw new IllegalArgumentException("Invalid userInput.", pe);
+        }
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} by {@code parser} is unsuccessful and the error message
+     * equals to {@code expectedMessage}.
+     */
+    public static void assertParseFailure(Parser parser, String userInput, String expectedMessage) {
+        try {
+            parser.parse(userInput);
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(expectedMessage, pe.getMessage());
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,34 +1,33 @@
-// package seedu.address.logic.parser;
-//
-// import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-// import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-// import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-//
-// import java.util.Arrays;
-//
-// import org.junit.jupiter.api.Test;
-//
-// import seedu.address.model.person.NameContainsKeywordsPredicate;
-//
-// public class FindCommandParserTest {
-//
-//     private FindCommandParser parser = new FindCommandParser();
-//
-//     @Test
-//     public void parse_emptyArg_throwsParseException() {
-//         assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-//         FindCommand.MESSAGE_USAGE));
-//     }
-//
-//     @Test
-//     public void parse_validArgs_returnsFindCommand() {
-//         // no leading and trailing whitespaces
-//         FindCommand expectedFindCommand =
-//                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-//         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
-//
-//         // multiple whitespaces between keywords
-//         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
-//     }
-//
-// }
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.recipe.RecipeContainsKeywordPredicate;
+
+class FindCommandParserTest {
+
+    private final FindCommandParser parser = new FindCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsException() {
+        assertParseFailure(parser, " ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindCommand() throws ParseException {
+        RecipeContainsKeywordPredicate pred = new RecipeContainsKeywordPredicate(List.of("Western", "Bacon"));
+        FindCommand expected = new FindCommand(pred);
+
+        assertParseSuccess(parser, "Western, Bacon", expected);
+        assertParseSuccess(parser, "      Western \r\n\t\t,    Bacon", expected);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -4,6 +4,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
@@ -51,5 +55,30 @@ public class TestUtil {
      */
     public static Recipe getRecipe(Model model, Index index) {
         return model.getFilteredRecipeList().get(index.getZeroBased());
+    }
+
+    /**
+     * Helper function to check the equality of {@code filteredList}. <br>
+     * This method exists as current list equality checks also consider matching the index of each element, this
+     * means that element at index 3 of one list has to be the same at index 3 on the other list. There are
+     * workarounds to this by using {@link List#containsAll(Collection)} but this method also allows checking for the
+     * uniqueness of its elements.
+     *
+     * @param modelList {@code filteredList} from {@code Model} after its predicate has been updated.
+     * @param expectedList {@code List} of unique elements that {@code modelList} is expected to have.
+     * @return true if the uniqueness and size of both lists are equal.
+     */
+    public static <T> boolean filteredListEquality(List<T> modelList, List<T> expectedList) {
+        Set<T> modelSet = new HashSet<>(modelList);
+        if (modelSet.size() != expectedList.size()) {
+            return false;
+        }
+
+        for (T t : expectedList) {
+            if (!modelSet.contains(t)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalRecipes.java
+++ b/src/test/java/seedu/address/testutil/TypicalRecipes.java
@@ -1,8 +1,5 @@
 package seedu.address.testutil;
 
-
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import seedu.address.model.RecipeBook;

--- a/src/test/java/seedu/address/testutil/TypicalRecipes.java
+++ b/src/test/java/seedu/address/testutil/TypicalRecipes.java
@@ -91,7 +91,6 @@ public class TypicalRecipes {
     }
 
     public static List<Recipe> getTypicalRecipes() {
-        return new ArrayList<>(Arrays.asList(AGLIO_OLIO, FRIED_RICE, DUCK_RICE, SUSHI, BEEF_TACO, SHOYU_RAMEN,
-                FISH_CHIPS, BOLOGNESE));
+        return List.of(AGLIO_OLIO, FRIED_RICE, DUCK_RICE, SUSHI, BEEF_TACO, SHOYU_RAMEN, FISH_CHIPS, BOLOGNESE);
     }
 }


### PR DESCRIPTION
Overview of changes:
1. FindCommand now supplies an immutable list to RecipeContainsKeywordPredicate
2. FindCommand test should cover most combinations of cases
3. Uncommented CommandParserUtil, no changes were needed and this change was necessary to test FindCommandParser, and I assume all the other *Parser files.
4. Included a `filteredListEquality` method in `TestUtil` as List equality also checks if an item is at the same index as another item.
    - If object A is at index 3 in List A, object A must also be at index 3 of List B for them to be equal. 
5. Minor change in `getTypicalRecipes` to make it immutable.

@AY2122S2-CS2103T-T17-2/developers try to merge this issue first as I feel like you guys may need `CommandParserUtil`.

Closes #114.
Closes #115.