### PR TITLE
Update: allow multiple input arguments to be entered within a single flag (separated by commas)

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -102,18 +102,22 @@ public class ArgumentTokenizer {
         for (int i = 0; i < prefixPositions.size() - 1; i++) {
             // Extract and store prefixes and their arguments
             Prefix argPrefix = prefixPositions.get(i).getPrefix();
-            String argValue = extractArgumentValue(argsString, prefixPositions.get(i), prefixPositions.get(i + 1));
-            argMultimap.put(argPrefix, argValue);
+            List<String> argValues = extractArgumentValue(argsString, prefixPositions.get(i),
+                    prefixPositions.get(i + 1));
+
+            for (String argValue: argValues) {
+                argMultimap.put(argPrefix, argValue);
+            }
         }
 
         return argMultimap;
     }
 
     /**
-     * Returns the trimmed value of the argument in the arguments string specified by {@code currentPrefixPosition}.
+     * Returns the trimmed value(s) of the argument in the arguments string specified by {@code currentPrefixPosition}.
      * The end position of the value is determined by {@code nextPrefixPosition}.
      */
-    private static String extractArgumentValue(String argsString,
+    private static List<String> extractArgumentValue(String argsString,
                                         PrefixPosition currentPrefixPosition,
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
@@ -121,7 +125,10 @@ public class ArgumentTokenizer {
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
-        return value.trim();
+        List<String> multiValue =
+                Arrays.stream(value.split(",")).map(v -> v.trim()).collect(Collectors.toList());
+
+        return multiValue;
     }
 
     /**
@@ -144,5 +151,4 @@ public class ArgumentTokenizer {
             return prefix;
         }
     }
-
 }


### PR DESCRIPTION
Allow all prefixes to parse comma seperated values, allowing users to simply use a single flag to add multiple values.

E.g.

Instead of:
`Add -t Tag1 -t Tag2 -t Tag3`

Users can now do:
`Add -t Tag1, Tag2, Tag3`
