### PR TITLE
Refactor: abstracted out symbol used to delimit multiple arguments for prefixes

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -126,7 +126,8 @@ public class ArgumentTokenizer {
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
         List<String> multiValue =
-                Arrays.stream(value.split(",")).map(v -> v.trim()).collect(Collectors.toUnmodifiableList());
+                Arrays.stream(value.split(RecipeBookSyntax.SEPARATOR_SYMBOL))
+                        .map(v -> v.trim()).collect(Collectors.toUnmodifiableList());
 
         return multiValue;
     }

--- a/src/main/java/seedu/address/logic/parser/RecipeBookSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookSyntax.java
@@ -16,5 +16,5 @@ public class RecipeBookSyntax {
     /** Used to indicate index in a command */
     public static final Prefix PREFIX_INDEX = new Prefix("-x ");
 
-    public static final String SEPARATOR_SYMBOL = "  ";
+    public static final String SEPARATOR_SYMBOL = "\\|";
 }

--- a/src/main/java/seedu/address/logic/parser/RecipeBookSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookSyntax.java
@@ -15,4 +15,6 @@ public class RecipeBookSyntax {
 
     /** Used to indicate index in a command */
     public static final Prefix PREFIX_INDEX = new Prefix("-x ");
+
+    public static final String SEPARATOR_SYMBOL = "  ";
 }


### PR DESCRIPTION
Closes #178

Current delimiter is "  " instead of "," due to "|" and "+" both causing issues with the tests, alternative suggestions are v welcome!