### PR TITLE
fix: ServingSize + CompletionTime parsing and ignore empty arguments …

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -80,14 +81,17 @@ public class StringUtil {
     }
 
     /**
-     * @return true if the double value of {@code s} is greater than 0.
+     * @return true if the double value of {@code s} is greater than 0 and
+     * has more than 2 decimal places
      */
     public static boolean isNonZeroPositiveDouble(String s) {
         requireNonNull(s);
 
         try {
             double value = Double.parseDouble(s);
-            return value > 0;
+            BigDecimal bdValue = BigDecimal.valueOf(value);
+            int scale = Math.abs(bdValue.scale());
+            return ((value > 0) && (scale < 3));
         } catch (NumberFormatException nfe) {
             return false;
         }

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.parser;
 
+import seedu.address.logic.parser.exceptions.ParseException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -125,11 +127,15 @@ public class ArgumentTokenizer {
         int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
-        List<String> multiValue =
-                Arrays.stream(value.split(RecipeBookSyntax.SEPARATOR_SYMBOL))
-                        .map(v -> v.trim()).collect(Collectors.toUnmodifiableList());
+        // remove empty arguments
+        List<String> multiValue = new ArrayList<>();
+        for (String v: value.split(RecipeBookSyntax.SEPARATOR_SYMBOL)) {
+            if (!v.trim().isEmpty()) {
+                multiValue.add(v);
+            }
+        }
 
-        return multiValue;
+        return List.copyOf(multiValue);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
@@ -31,8 +31,8 @@ public class RecipeBookParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      * @throws ParseException if the index is invalid (not a non-zero positive integer).
      */
-    public static Index parseIndex(String oneBasedIndex) throws ParseException {
-        String trimmedIndex = oneBasedIndex.trim();
+    public static Index parseIndex(String oneBasedIndexString) throws ParseException {
+        String trimmedIndex = oneBasedIndexString.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(Messages.MESSAGE_INVALID_RECIPE_INDEX);
         }
@@ -44,13 +44,18 @@ public class RecipeBookParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      * @throws ParseException if the given {@code name} is invalid.
      */
-    public static Name parseName(String name) throws ParseException {
-        requireNonNull(name);
-        String trimmedName = name.trim();
+    public static Name parseName(String nameString) throws ParseException {
+        requireNonNull(nameString);
+        String trimmedName = nameString.trim();
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }
-        return new Name(trimmedName);
+
+        try {
+            return new Name(trimmedName);
+        } catch (IllegalArgumentException err) {
+            throw new ParseException(err.getMessage());
+        }
     }
 
     /**
@@ -58,14 +63,19 @@ public class RecipeBookParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      * @throws ParseException if the time is invalid (not a non-zero positive integer).
      */
-    public static CompletionTime parseCompletionTime(String time) throws ParseException {
-        requireNonNull(time);
+    public static CompletionTime parseCompletionTime(String timeString) throws ParseException {
+        requireNonNull(timeString);
 
-        String trimmedTime = time.trim();
+        String trimmedTime = timeString.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedTime)) {
             throw new ParseException(CompletionTime.MESSAGE_CONSTRAINTS);
         }
-        return new CompletionTime(Integer.parseInt(trimmedTime));
+
+        try {
+            return new CompletionTime(Integer.parseInt(trimmedTime));
+        } catch (IllegalArgumentException err) {
+            throw new ParseException(err.getMessage());
+        }
     }
 
     /**
@@ -73,12 +83,19 @@ public class RecipeBookParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      * @throws ParseException if the ServingSize is invalid (not a non-zero positive number).
      */
-    public static ServingSize parseServingSize(String servingSize) throws ParseException {
-        String trimmedSize = servingSize.trim();
-        if (!StringUtil.isNonZeroPositiveDouble(trimmedSize)) {
+    public static ServingSize parseServingSize(String servingSizeString) throws ParseException {
+        requireNonNull(servingSizeString);
+
+        String trimmedSize = servingSizeString.trim();
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedSize)) {
             throw new ParseException(ServingSize.MESSAGE_CONSTRAINTS);
         }
-        return new ServingSize(Integer.parseInt(servingSize));
+
+        try {
+            return new ServingSize(Integer.parseInt(trimmedSize));
+        } catch (IllegalArgumentException err) {
+            throw new ParseException(err.getMessage());
+        }
     }
 
 

--- a/src/main/java/seedu/address/model/recipe/CompletionTime.java
+++ b/src/main/java/seedu/address/model/recipe/CompletionTime.java
@@ -11,7 +11,9 @@ import java.util.Objects;
  */
 public class CompletionTime {
 
-    public static final String MESSAGE_CONSTRAINTS = "Completion time should be greater than 0";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Completion time should be a valid, reasonable amount of time in minutes that's greater than 0 "
+                    + "and less than a year";
 
     public final Integer value;
 
@@ -23,12 +25,18 @@ public class CompletionTime {
     public CompletionTime(Integer completionTime) {
         requireNonNull(completionTime);
         checkArgument(isValidCompletionTime(completionTime), MESSAGE_CONSTRAINTS);
-
         value = completionTime;
     }
 
+    /**
+     * Checks that given completion time is greater than 0 and shorter
+     * than a day (24 hours in minutes)
+     *
+     * @param test given completion time input
+     * @return whether given input is a valid completion time
+     */
     public static boolean isValidCompletionTime(Integer test) {
-        return (test > 0);
+        return (test > 0 && test < 525600);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/recipe/ServingSize.java
+++ b/src/main/java/seedu/address/model/recipe/ServingSize.java
@@ -9,8 +9,10 @@ import java.util.Objects;
  * Guarantees: immutable; is valid as declared in {@link #isValidServingSize(Integer)}
  */
 public class ServingSize {
+
     public static final String MESSAGE_CONSTRAINTS =
-            "ServingSize size should not be left blank or less than or equals to 0";
+            "ServingSize size should be a valid, reasonable amount of servings that's greater than 0 "
+                    + "and less than 1000 servings (that's literally impossible)";
 
     public final Integer value;
 
@@ -26,10 +28,10 @@ public class ServingSize {
     }
 
     /**
-     * Checks if the size is a valid Integer value > 0.
+     * Checks if the size is a valid Integer between 0 and 1000.
      */
     public static boolean isValidServingSize(Integer test) {
-        return test > 0;
+        return (test > 0 && test < 1000);
     }
 
     @Override


### PR DESCRIPTION
Fixes #206 and #204:
- issue: empty arguments are parsed and error returned
- solution: command works but ignores all empty arguments without returning any errors

Fixes #201 and #184:
- issue: completion time error shows "should be greater than 0" for values that are above int.MAX_VALUE
- solution: set both completion time and serving size as integers and fix upper limits for both (completion time < 1 year in minutes, serving size < 1000 pax)

TODO:
- update: add to UG/DG to remind users that having empty arguments wont break the command e.g. "edit -i Ingredient1 5 kg | | | | | |" will work)
- update: add to UG/DG to remind users that completion time and serving size are both integers and have upper limits (< 1 year for completion time and < 1000 pax for serving size)