### PR TITLE
fix: handle integer overflow issues when input integer is larger than Int.MAX_VALUE

### DIFF
--- a/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParserUtil.java
@@ -75,7 +75,7 @@ public class RecipeBookParserUtil {
      */
     public static ServingSize parseServingSize(String servingSize) throws ParseException {
         String trimmedSize = servingSize.trim();
-        if (!StringUtil.isNonZeroPositiveDouble(trimmedSize)) {
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedSize)) {
             throw new ParseException(ServingSize.MESSAGE_CONSTRAINTS);
         }
         return new ServingSize(Integer.parseInt(servingSize));

--- a/src/main/java/seedu/address/model/recipe/CompletionTime.java
+++ b/src/main/java/seedu/address/model/recipe/CompletionTime.java
@@ -30,7 +30,7 @@ public class CompletionTime {
     }
 
     public static boolean isValidCompletionTime(Integer test) {
-        return (test > 0 && test < 525600);
+        return (test > 0 && test <= 525600);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/recipe/CompletionTime.java
+++ b/src/main/java/seedu/address/model/recipe/CompletionTime.java
@@ -11,7 +11,9 @@ import java.util.Objects;
  */
 public class CompletionTime {
 
-    public static final String MESSAGE_CONSTRAINTS = "Completion time should be greater than 0";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Completion time should be a valid, reasonable amount of time in minutes that's greater than 0 "
+                    + "and less than a year";
 
     public final Integer value;
 
@@ -28,7 +30,7 @@ public class CompletionTime {
     }
 
     public static boolean isValidCompletionTime(Integer test) {
-        return (test > 0);
+        return (test > 0 && test < 525600);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/recipe/ServingSize.java
+++ b/src/main/java/seedu/address/model/recipe/ServingSize.java
@@ -10,7 +10,8 @@ import java.util.Objects;
  */
 public class ServingSize {
     public static final String MESSAGE_CONSTRAINTS =
-            "ServingSize size should not be left blank or less than or equals to 0";
+            "ServingSize size should be a valid, reasonable amount of servings that's greater than 0 "
+                    + "and less than 1000 servings (that's literally impossible)";
 
     public final Integer value;
 
@@ -29,7 +30,7 @@ public class ServingSize {
      * Checks if the size is a valid Integer value > 0.
      */
     public static boolean isValidServingSize(Integer test) {
-        return test > 0;
+        return (test > 0 && test < 1000);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/recipe/ServingSize.java
+++ b/src/main/java/seedu/address/model/recipe/ServingSize.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 public class ServingSize {
     public static final String MESSAGE_CONSTRAINTS =
             "ServingSize size should be a valid, reasonable amount of servings that's greater than 0 "
-                    + "and less than 1000 servings (that's literally impossible)";
+                    + "and less than 1000 servings";
 
     public final Integer value;
 

--- a/src/main/java/seedu/address/model/recipe/ServingSize.java
+++ b/src/main/java/seedu/address/model/recipe/ServingSize.java
@@ -30,7 +30,7 @@ public class ServingSize {
      * Checks if the size is a valid Integer value > 0.
      */
     public static boolean isValidServingSize(Integer test) {
-        return (test > 0 && test < 1000);
+        return (test > 0 && test <= 1000);
     }
 
     @Override


### PR DESCRIPTION
Fixes #201 and #184:
- issue: completion time error shows "should be greater than 0" for values that are above int.MAX_VALUE
- solution: set both completion time and serving size as integers and fix upper limits for both (completion time < 1 year in minutes, serving size < 1000 pax)

TODO:
- update: add to UG/DG to remind users that completion time and serving size are both integers and have upper limits (< 1 year for completion time and < 1000 pax for serving size)