### PR TITLE
fix: parsing prefix issue when user inputs prefixes without space after

### DIFF
--- a/src/main/java/seedu/address/logic/parser/RecipeBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/RecipeBookParser.java
@@ -49,7 +49,7 @@ public class RecipeBookParser {
         }
 
         final String commandWord = matcher.group("commandWord");
-        final String arguments = matcher.group("arguments");
+        final String arguments = matcher.group("arguments") + " ";
 
         if (!requiresConfirmationClear && !requiresConfirmationReset) {
             switch (commandWord) {


### PR DESCRIPTION
Fixes #216:
- issue: incorrect error message for edit with empty fields due to parser not having a way to deal with issue when user inputs prefixes with missing space
e.g edit -x 2 -t registers "2 -t" as index value
e.g. edit -x 2 -ss 12 -t registers "12 -t" as serving size
- solution: add single space " " to end of user input argument value