### PR TITLE
fix: clear and reset parser not removing the excess space added used to fix previous issues

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -20,7 +20,7 @@ public class ClearCommandParser implements Parser<ClearCommand> {
      */
 
     public static boolean isNotForcedClear(String arguments) {
-        return arguments.isEmpty();
+        return arguments.trim().isEmpty();
     }
 
     /**
@@ -35,7 +35,7 @@ public class ClearCommandParser implements Parser<ClearCommand> {
     public ClearCommand parse(String userInput) throws ParseException {
         if (userInput.equals(FORCED_COMMAND_TAG)) {
             return new ConfirmedClearCommand();
-        } else if (userInput.isEmpty()) {
+        } else if (userInput.trim().isEmpty()) {
             return new ClearCommand();
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClearCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
@@ -20,7 +20,7 @@ public class ResetCommandParser implements Parser<ResetCommand> {
      */
 
     public static boolean isNotForcedReset(String arguments) {
-        return arguments.isEmpty();
+        return arguments.trim().isEmpty();
     }
 
     /**
@@ -35,7 +35,7 @@ public class ResetCommandParser implements Parser<ResetCommand> {
     public ResetCommand parse(String userInput) throws ParseException {
         if (userInput.equals(FORCED_COMMAND_TAG)) {
             return new ConfirmedResetCommand();
-        } else if (userInput.isEmpty()) {
+        } else if (userInput.trim().isEmpty()) {
             return new ResetCommand();
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ResetCommand.MESSAGE_USAGE));


### PR DESCRIPTION
Fixes #249 

Issue: clear and reset command parsers weren't updated to trim the excess " " added that handles issue of users adding invalid arguments that weren't caught by parsers since our tokens expect an excess space at the end.

Fix: adds .trim() functions in clear and reset command parsers