### PR TITLE
fix: forced reset and clear command not working due to excess whitespaces

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClearCommandParser.java
@@ -11,7 +11,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new ClearCommand object.
  */
 public class ClearCommandParser implements Parser<ClearCommand> {
-    private static final String FORCED_COMMAND_TAG = " -f";
+    private static final String FORCED_COMMAND_TAG = "-f";
     /**
      * Checks whether the ClearCommand is a forced clear.
      *
@@ -33,7 +33,7 @@ public class ClearCommandParser implements Parser<ClearCommand> {
      */
     @Override
     public ClearCommand parse(String userInput) throws ParseException {
-        if (userInput.equals(FORCED_COMMAND_TAG)) {
+        if (userInput.trim().equals(FORCED_COMMAND_TAG)) {
             return new ConfirmedClearCommand();
         } else if (userInput.trim().isEmpty()) {
             return new ClearCommand();

--- a/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ResetCommandParser.java
@@ -11,7 +11,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new ResetCommand object.
  */
 public class ResetCommandParser implements Parser<ResetCommand> {
-    private static final String FORCED_COMMAND_TAG = " -f";
+    private static final String FORCED_COMMAND_TAG = "-f";
     /**
      * Checks whether the ResetCommand is a forced Reset.
      *
@@ -33,7 +33,7 @@ public class ResetCommandParser implements Parser<ResetCommand> {
      */
     @Override
     public ResetCommand parse(String userInput) throws ParseException {
-        if (userInput.equals(FORCED_COMMAND_TAG)) {
+        if (userInput.trim().equals(FORCED_COMMAND_TAG)) {
             return new ConfirmedResetCommand();
         } else if (userInput.trim().isEmpty()) {
             return new ResetCommand();

--- a/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClearCommandParserTest.java
@@ -18,7 +18,7 @@ public class ClearCommandParserTest {
 
     private final ClearCommandParser parser = new ClearCommandParser();
     private final String clearCommand = "";
-    private final String confirmedClear = " -f";
+    private final String confirmedClear = "-f";
 
     /**
      * Tests the isNotForcedClearCommand.

--- a/src/test/java/seedu/address/logic/parser/ResetCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ResetCommandParserTest.java
@@ -17,7 +17,7 @@ public class ResetCommandParserTest {
 
     private final ResetCommandParser parser = new ResetCommandParser();
     private final String resetCommand = "";
-    private final String confirmedReset = " -f";
+    private final String confirmedReset = "-f";
 
     /**
      * Tests the isNotForcedResetCommand.


### PR DESCRIPTION
fix: forced reset and clear command not working due to excess whitespaces